### PR TITLE
Add pluggable validation method for items returned from local storage

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -121,6 +121,10 @@
 		return obj;
 	};
 
+	var isValidItem = function(source, obj) {
+		return  (!source || source.expire - +new Date() < 0  || obj.unique !== source.unique || (basket.isValidItem && !basket.isValidItem(source, obj)));
+	};
+
 	var handleStackObject = function( obj ) {
 		var source, promise;
 
@@ -133,7 +137,7 @@
 
 		obj.execute = obj.execute !== false;
 
-		if ( !source || source.expire - +new Date() < 0  || obj.unique !== source.unique ) {
+		if (isValidItem(source, obj)) {
 			if ( obj.unique ) {
 				// set parameter to prevent browser cache
 				obj.url += ( ( obj.url.indexOf('?') > 0 ) ? '&' : '?' ) + 'basket-unique=' + obj.unique;
@@ -188,7 +192,9 @@
 			}
 
 			return this;
-		}
+		},
+
+		isValidItem: null
 	};
 
 	// delete expired keys

--- a/test/tests.js
+++ b/test/tests.js
@@ -284,3 +284,24 @@ asyncTest( 'handle the case where localStorage contains something we did not exp
 			ok( basket.get( 'test' ).key === 'test', 'got a valid cache object' );
 		});
 });
+
+asyncTest( 'file is fetched from server even it exists when isValidItem answers no', 2, function() {
+		basket
+			.require({ url: 'fixtures/stamp-script.js'})
+			.then(function() {
+				var stamp = basket.get('fixtures/stamp-script.js').stamp;
+				ok( basket.get('fixtures/stamp-script.js'), 'Data exists in localStorage' );
+				basket.isValidItem = function(source, obj) {
+					return false;
+				};
+				basket
+					.require({ url: 'fixtures/stamp-script.js' })
+					.then(function() {
+						var stampAfter = basket.get('fixtures/stamp-script.js').stamp;
+						ok( stamp !== stampAfter, 'Data retrieved from server' );
+
+						start();
+					});
+			});
+});
+


### PR DESCRIPTION
This is a proposed change that would allow users of basket to add additional validations before using content from local storage.

For instance, one could verify a checksum of components stored in basket - if the checksum fails, a new file will be sourced.

Basket currently checks to ensure that it has an 'item' but doesn't have any ability to check other cases

I'm open to feedback as to the best way to support the pluggable aspect of this.

Feedback welcome
