### PR TITLE
Fix broken rsvp ref for correct mime type...

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
 			<p><em>This section was rendered using the micro-templating in Underscore.js. It's just one of a number of scripts that were added to this document using basket.js when you loaded it and should now be <strong>cached</strong> in localStorage (if supported). If you visit this page again, the scripts will be loaded from there rather than being refetched. Backbone.js was also loaded and we created a new model with the name: <%= name %> (just for funsies).</em></p>
 		</script>
 		<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-		<script src="https://raw.github.com/tildeio/rsvp.js/1.0.0/browser/rsvp.min.js"></script>
+		<script src="https://rawgithub.com/tildeio/rsvp.js/1.0.0/browser/rsvp.min.js"></script>
 		<script src="dist/basket.min.js"></script>
 		<script>
 			basket


### PR DESCRIPTION
Original responds now with text/plain, updated version will respond with application/javascript.

Original no longer works (not sure if there are other errors as well) on http://addyosmani.github.io/basket.js/ on any browser I tried.

Refused to execute script from 'https://raw.github.com/tildeio/rsvp.js/1.0.0/browser/rsvp.min.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled. addyosmani.github.io/basket.js/:1
Uncaught ReferenceError: RSVP is not defined basket.min.js:10
Uncaught ReferenceError: basket is not defined
