### PR TITLE
Some minor fixes after the recent dep upgrades

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bower_components"
-}

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -45,7 +45,7 @@
 
 	var getUrl = function( url ) {
 		var promise = new RSVP.Promise( function( resolve, reject ){
-		  
+
 			var xhr = new XMLHttpRequest();
 			xhr.open( 'GET', url );
 
@@ -64,12 +64,11 @@
 
 			// By default XHRs never timeout, and even Chrome doesn't implement the
 			// spec for xhr.timeout. So we do it ourselves.
-			/*
 			setTimeout( function () {
 				if( xhr.readyState < 4 ) {
 					xhr.abort();
 				}
-			}, basket.timeout );*/
+			}, basket.timeout );
 
 			xhr.send();
 		});

--- a/test/tests.js
+++ b/test/tests.js
@@ -252,8 +252,7 @@ asyncTest( 'remove oldest script in localStorage when Quote Exceeded', 2, functi
 asyncTest( 'file is larger than quota limit ', 2, function() {
 	basket
 		.require({ url: 'fixtures/largeScript.js', key: 'largeScript0' }, { url: 'fixtures/largeScript.js', key: 'largeScript1' })
-		.then();
-	basket.require({ url: 'fixtures/veryLargeScript.js', key: 'largeScript2' })
+		.thenRequire({ url: 'fixtures/veryLargeScript.js', key: 'largeScript2' })
 		.then(function() {
 			// check if scripts added was removed from localStorage
 			ok( !basket.get( 'largeScript0' ) , 'First Script deleted' );
@@ -609,7 +608,7 @@ asyncTest( 'with live: true, we still store the result in the cache', 1, functio
 
 	server.respond();
 });
-/*
+
 asyncTest( 'with live: true, we fallback to the cache', 2, function() {
 	// TODO: How to test the navigator.onLine case?
 	basket.clear();
@@ -648,4 +647,3 @@ asyncTest( 'with live: true, we fallback to the cache', 2, function() {
 	server.respond();
 	basket.timeout = 5000;
 });
-*/


### PR DESCRIPTION
- .bowerrc isn't needed since RSVP was upgraded
- Uncommented the request timeout
- Added the live:true test back in (broken by the above commenting)
