### PR TITLE
Add fallback URL functionality

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -44,6 +44,9 @@
 	};
 
 	var getUrl = function( url ) {
+		if (url instanceof Array) {
+			return getUrls(url);
+		}
 		var promise = new RSVP.Promise( function( resolve, reject ){
 
 			var xhr = new XMLHttpRequest();
@@ -71,6 +74,29 @@
 			}, basket.timeout );
 
 			xhr.send();
+		});
+
+		return promise;
+	};
+
+	var getUrls = function(urls) {
+		var index = 0;
+		var promise = new RSVP.Promise( function( resolve, reject ){
+			var tryGet = function() {
+				getUrl(urls[index]).then(
+					function (result) {
+						resolve(result);
+					},
+					function error(e) {
+						++index;
+						if (urls[index]) {
+							tryGet();
+						} else {
+							reject(e);
+						}
+					});
+			};
+			tryGet();
 		});
 
 		return promise;
@@ -111,7 +137,7 @@
 			return;
 		}
 
-		obj.key =  ( obj.key || obj.url );
+		obj.key =  ( obj.key || (obj.url instanceof Array ? obj.url[0] : obj.url ));
 		source = basket.get( obj.key );
 
 		obj.execute = obj.execute !== false;

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -80,23 +80,21 @@
 	};
 
 	var getUrls = function(urls) {
-		var index = 0;
 		var promise = new RSVP.Promise( function( resolve, reject ){
-			var tryGet = function() {
+			var tryGet = function(index) {
 				getUrl(urls[index]).then(
 					function (result) {
 						resolve(result);
 					},
 					function error(e) {
-						++index;
-						if (urls[index]) {
-							tryGet();
+						if (urls[index+1]) {
+							tryGet(index+1);
 						} else {
 							reject(e);
 						}
 					});
 			};
-			tryGet();
+			tryGet(0);
 		});
 
 		return promise;

--- a/test/tests.js
+++ b/test/tests.js
@@ -538,6 +538,70 @@ asyncTest( 'with array of urls, we try the second if the first 404s', 1, functio
 		});
 });
 
+asyncTest( 'require() 1 script with fallback', 2, function() {
+	var cancel = setTimeout(function() {
+		ok( false, 'Callback never invoked' );
+		start();
+	}, 2500);
+
+	basket.require(
+		{url: ['cdn/jquery.min.js', 'fixtures/jquery.min.js']}
+	)
+	.then(function() {
+		clearTimeout( cancel );
+
+		ok( true, 'Callback invoked' );
+		ok( basket.get('cdn/jquery.min.js'), 'Data exists in localStorage' );
+
+		start();
+	});
+});
+
+
+asyncTest( 'require() 2 scripts with .then() with fallback', 3, function() {
+	var cancel = setTimeout(function() {
+		ok( false, 'Callback never invoked' );
+		start();
+	}, 2500);
+
+	basket.require(
+			{ url: ['cdn/jquery.min.js', 'fixtures/jquery.min.js'] },
+			{ url: ['cdn/modernizr.min.js', 'fixtures/modernizr.min.js'] }
+		)
+		.then(function() {
+			clearTimeout( cancel );
+
+			ok( true, 'Callback invoked' );
+			ok( basket.get('cdn/jquery.min.js'), 'Data exists in localStorage' );
+			ok( basket.get('cdn/modernizr.min.js'), 'Data exists in localStorage' );
+
+			start();
+		});
+});
+
+
+asyncTest( 'require() 2 scripts (one non-executed) with .then() with fallback', 4, function() {
+	var cancel = setTimeout(function() {
+		ok( false, 'Callback never invoked' );
+		start();
+	}, 2500);
+
+	basket.require(
+			{ url: ['cdn/fail-script.js', 'fixtures/fail-script.js'], execute: false },
+			{ url: ['cdn/modernizr.min.js', 'fixtures/modernizr.min.js'] }
+		)
+		.then(function() {
+			clearTimeout( cancel );
+
+			ok( true, 'Callback invoked' );
+			ok( basket.get('cdn/modernizr.min.js'), 'Data exists in localStorage' );
+			ok( basket.get('cdn/fail-script.js'), 'Data exists in localStorage' );
+			ok( basket.fail !== true, 'Script not executed' );
+
+			start();
+		});
+});
+
 // This test is here to cover the full set of possibilities for this section
 // It doesn't really test anything that hasn't been tested elsewhere
 asyncTest( 'with live: false, we fallback to the network', 1, function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -524,6 +524,20 @@ asyncTest( 'type falls back to Content-Type, even if previously overriden', 2, f
 	server.respond();
 });
 
+asyncTest( 'with array of urls, we try the second if the first 404s', 1, function() {
+	basket.clear();
+
+	basket.require({ url: ['fixtures/fail.js', 'fixtures/first.js'], key: 'fellback' })
+		.then(function () {
+			start();
+			ok(basket.get('fellback'), 'fell back to alternate URL');
+		},
+		function() {
+			start();
+			ok(false, 'it did not work', 'it did not work');
+		});
+});
+
 // This test is here to cover the full set of possibilities for this section
 // It doesn't really test anything that hasn't been tested elsewhere
 asyncTest( 'with live: false, we fallback to the network', 1, function() {


### PR DESCRIPTION
This change allows an array of URLs to be passed for a script, where if the first URL fails the loader will try the next, and so on, similar to the Require.js feature. I noticed that on the Basket.js homepage it says that only same-origin URIs are supported, but the XHR approach will work fine with modern browsers and most CDNs allow an Access-Control-Allow-Origin wildcard, so I think this adds value.
