### PR TITLE
Add skipCache option to not store data in localStorage but still fetch it

### DIFF
--- a/_includes/api.md
+++ b/_includes/api.md
@@ -31,6 +31,7 @@ See the updated documentation below for more details.
 * **expire** How long (in hours) before the cached item expires.
 * **execute** Whether to cause the script to be executed once it has been retrieved. Defaults to true.
 * **unique** A token stored with the cached item. If you request the same item again with a different token the script will be fetched and cached again.
+* **skipCache** Prevent storing the script in cache. Useful when you want load scripts in order, but only cache some. By default is *false*.
 
 `require()` returns a [promise](http://wiki.commonjs.org/wiki/Promises/A) that will be fulfilled when each of the requested items has been fetched, or rejected if any item fails.
 
@@ -55,6 +56,18 @@ basket.require(
 ```
 
 Multiple scripts will be requested. The scripts are requested asynchronously and so may load and execute in any order.
+
+**Multiple scripts without caching some of them**
+
+```javascript
+basket.require(
+	{ url: 'require.js' },
+	{ url: 'require.config.js', skipCache: true },
+	{ url: 'libs.js' }
+);
+```
+
+Multiple scripts will be requested. `require.config.js` will not be cached in localStorage. Useful if order of scripts execution is important but storing certain script is not needed, e.g. it changes with each request.
 
 **Ordering dependencies**
 

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -80,7 +80,9 @@
 		return getUrl( obj.url ).then( function( result ) {
 			var storeObj = wrapStoreData( obj, result );
 
-			addLocalStorage( obj.key , storeObj );
+			if (!obj.skipCache) {
+				addLocalStorage( obj.key , storeObj );
+			}
 
 			return storeObj;
 		});
@@ -91,6 +93,7 @@
 		obj.data = data.content;
 		obj.originalType = data.type;
 		obj.type = obj.type || data.type;
+		obj.skipCache = obj.skipCache || false;
 		obj.stamp = now;
 		obj.expire = now + ( ( obj.expire || defaultExpiration ) * 60 * 60 * 1000 );
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -647,3 +647,13 @@ asyncTest( 'with live: true, we fallback to the cache', 2, function() {
 	server.respond();
 	basket.timeout = 5000;
 });
+
+asyncTest( 'with skipCache: true, we do not cache data', 1, function() {
+	basket
+		.require({ url: 'fixtures/jquery.min.js', skipCache: true })
+		.then(function() {
+			ok( !basket.get('fixtures/jquery.min.js'), 'Data does not exist in localStorage' );
+
+			start();
+		});
+});


### PR DESCRIPTION
I believe it would be useful to have an option to skip storing data in the local storage.

In my use case I want to fetch several scripts using basket in parallel and then store all but one.
It is needed as data is user specific, needed only for this session and defines flow of the scripts after it (some flags, etc).

Example:

``` js
basket.require(
    { url: 'jquery.js' },
    { url: 'component1.js' },
    { url: 'config.specific.just.for.this.session', skipCache: true },
    { url: 'component2.which.uses.flags.from.config' }
);
```

Order of the scripts is important here. It is just perfect to store common libs and components but that config will never be used again, there is no use to store it.
I know that there is `unique` flag but it will just force overwrite everytime and I would like to skip that overhead.
