### PR TITLE
Execute source from cache when previously set not to execute

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -140,6 +140,7 @@
 			}
 		} else {
 			source.type = obj.type || source.originalType;
+			source.execute = obj.execute;
 			promise = new RSVP.Promise( function( resolve ){
 				resolve( source );
 			});

--- a/test/tests.js
+++ b/test/tests.js
@@ -675,3 +675,29 @@ asyncTest( 'with skipCache: true, we do not cache data', 1, function() {
 			start();
 		});
 });
+
+asyncTest( 'execute a cached script when execute: true', 2, function() {
+	var cancel = setTimeout(function() {
+		ok( false, 'Callback never invoked' );
+		start();
+	}, 2500);
+
+	function requireScript(execute, cb) {
+		basket.require(
+			{ url: 'fixtures/noexecute.js', execute: execute }
+		)
+		.then(cb);
+	}
+
+	requireScript( false, function() {
+		clearTimeout( cancel );
+
+		ok( typeof basket.executed === 'undefined', 'None-cached script was not executed' );
+
+		requireScript( true, function() {
+			ok( basket.executed === true, 'Cached script executed' );
+
+			start();
+		});
+	});
+});


### PR DESCRIPTION
When setting execute:false in a backet.require() call, that script is never executed when re-loaded from cache in future. If I load the same script in future with execute:true, I would expect the script to execute if it has been loaded from the cache.
