### PR TITLE
For loop optimization

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -203,7 +203,7 @@
 
 	window.basket = {
 		require: function() {
-			for ( var a = 0; a < arguments.length; a++ ) {
+			for ( var a = 0, l = arguments.length; a < l; a++ ) {
 				arguments[a].execute = arguments[a].execute !== false;
 				
 				if ( arguments[a].once && inBasket.indexOf(arguments[a].url) >= 0 ) {


### PR DESCRIPTION
Noticed that `fetch` cached the args length but `window.basket.require` did not.
