### PR TITLE
Refactored the way localStorage is used

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -9,7 +9,7 @@
 
 	var addLocalStorage = function( key, storeObj ) {
 		try {
-			localStorage.setItem( storagePrefix + key, JSON.stringify( storeObj ) );
+			localStorage[ storagePrefix + key ] = JSON.stringify( storeObj );
 			return true;
 		} catch( e ) {
 			if ( e.name.toUpperCase().indexOf('QUOTA') >= 0 ) {
@@ -225,7 +225,7 @@
 		},
 
 		get: function( key ) {
-			var item = localStorage.getItem( storagePrefix + key );
+			var item = localStorage[ storagePrefix + key ];
 			try	{
 				return JSON.parse( item || 'false' );
 			} catch( e ) {


### PR DESCRIPTION
Used localStorage[] instead of localStorage.get & localStorage.set
This closes issue #140 and can improve the performance of the library.
See:
http://jsperf.com/ready-from-localstorage-string
http://jsperf.com/reading-from-localstorage

Same test with a large 64KB string:
https://jsperf.com/ready-from-localstorage-string/4
