### PR TITLE
Support the XDomainRequest object of IE8 and IE9. Those browsers are …

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -46,32 +46,55 @@
 
 	var getUrl = function( url ) {
 		var promise = new RSVP.Promise( function( resolve, reject ){
+			var xhr;
+			
+			if (typeof XDomainRequest === 'undefined') {
+				xhr = new XMLHttpRequest();
 
-			var xhr = new XMLHttpRequest();
-			xhr.open( 'GET', url );
-
-			xhr.onreadystatechange = function() {
-				if ( xhr.readyState === 4 ) {
-					if ( ( xhr.status === 200 ) ||
-							( ( xhr.status === 0 ) && xhr.responseText ) ) {
-						resolve( {
-							content: xhr.responseText,
-							type: xhr.getResponseHeader('content-type')
-						} );
-					} else {
-						reject( new Error( xhr.statusText ) );
+				xhr.onreadystatechange = function() {
+					if ( xhr.readyState === 4 ) {
+						if ( ( xhr.status === 200 ) ||
+								( ( xhr.status === 0 ) && xhr.responseText ) ) {
+							resolve( {
+								content: xhr.responseText,
+								type: xhr.getResponseHeader('content-type')
+							} );
+						} else {
+							reject( new Error( xhr.statusText ) );
+						}
 					}
-				}
-			};
+				};
 
-			// By default XHRs never timeout, and even Chrome doesn't implement the
-			// spec for xhr.timeout. So we do it ourselves.
-			setTimeout( function () {
-				if( xhr.readyState < 4 ) {
-					xhr.abort();
-				}
-			}, basket.timeout );
-
+				// By default XHRs never timeout, and even Chrome doesn't implement the
+				// spec for xhr.timeout. So we do it ourselves.
+				setTimeout( function () {
+					if( xhr.readyState < 4 ) {
+						xhr.abort();
+					}
+				}, basket.timeout );
+			}
+			else {
+				/* XDomainRequest supports CORS ajax calls on IE8 and IE9 but with the following gotchas
+				 * 
+				 * 1. The server protocol must be the same as the calling page protocol.
+				 * 2. Only “text/plain” is supported for the request’s “Content Type header
+				 * 3. No custom headers can be added to the request
+				 */
+				
+				xhr = new XDomainRequest();
+				xhr.timeout = basket.timeout;
+				xhr.onload	= function() {
+					resolve( {
+						content: xhr.responseText,
+						type: xhr.contentType
+					} );
+				};
+				xhr.onerror = function(error) { 
+					reject( new Error( error ) );
+				};
+			}
+			
+			xhr.open( 'GET', url );
 			xhr.send();
 		});
 
@@ -85,7 +108,7 @@
 			if (!obj.skipCache) {
 				addLocalStorage( obj.key , storeObj );
 			}
-
+			
 			return storeObj;
 		});
 	};


### PR DESCRIPTION
…not able to do CORS request via the common XHR object.

By supporting the old api it is possible to fetch scripts from other domains with basket.js
