### PR TITLE
Support fake localStorage and new 'basket.ready()' method 

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -1,4 +1,4 @@
-/*global document, XMLHttpRequest, localStorage, basket, RSVP*/
+/*global document, XMLHttpRequest, basket, RSVP*/
 (function( window, document ) {
 	'use strict';
 
@@ -6,6 +6,22 @@
 	var storagePrefix = 'basket-';
 	var defaultExpiration = 5000;
 	var inBasket = [];
+	var mapKeyPromises={};
+
+	//
+	// testing localStorage the QUOTA exception 
+	// http://stackoverflow.com/questions/21159301/quotaexceedederror-dom-exception-22-an-attempt-was-made-to-add-something-to-st
+	var localStorage=window.localStorage;
+  try{
+	  window.localStorage.setItem('slkxjljc',1);
+	}catch(e){
+		// empty storage
+		localStorage={
+			setItem:function () {},
+			getItem:function () {},
+			removeItem:function (){}
+		};
+	}
 
 	var addLocalStorage = function( key, storeObj ) {
 		try {
@@ -63,6 +79,7 @@
 					}
 				}
 			};
+
 
 			// By default XHRs never timeout, and even Chrome doesn't implement the
 			// spec for xhr.timeout. So we do it ourselves.
@@ -148,6 +165,10 @@
 			});
 		}
 
+		//
+		// map promise with his obj.key
+		mapKeyPromises[obj.key]=promise;
+
 		return promise;
 	};
 
@@ -201,6 +222,7 @@
 		return promise;
 	};
 
+
 	window.basket = {
 		require: function() {
 			for ( var a = 0, l = arguments.length; a < l; a++ ) {
@@ -217,6 +239,10 @@
 
 			promise.thenRequire = thenRequire;
 			return promise;
+		},
+
+		ready:function (key) {
+			return mapKeyPromises[key];
 		},
 
 		remove: function( key ) {

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -6,10 +6,10 @@
 	var storagePrefix = 'basket-';
 	var defaultExpiration = 5000;
 	var inBasket = [];
-	var mapKeyPromises={};
+	var mapPromiseAndKey={};
 
 	//
-	// testing localStorage the QUOTA exception 
+	// testing the QUOTA exception with a tiny value
 	// http://stackoverflow.com/questions/21159301/quotaexceedederror-dom-exception-22-an-attempt-was-made-to-add-something-to-st
 	var localStorage=window.localStorage;
   try{
@@ -167,7 +167,7 @@
 
 		//
 		// map promise with his obj.key
-		mapKeyPromises[obj.key]=promise;
+		mapPromiseAndKey[obj.key]=promise;
 
 		return promise;
 	};
@@ -242,7 +242,7 @@
 		},
 
 		ready:function (key) {
-			return mapKeyPromises[key];
+			return mapPromiseAndKey[key];
 		},
 
 		remove: function( key ) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -88,6 +88,17 @@ asyncTest( 'require(), custom key', 1, function() {
 		});
 });
 
+asyncTest( 'require(), testing ready() with custom key', 1, function() {
+	var key = +new Date();
+
+	basket.require(
+		{ url: 'fixtures/jquery.min.js', key: key }
+	);
+	basket.ready(key).then(function() {
+			ok( basket.get(key), 'Data exists in localStorage under custom key' );
+			start();
+		});
+});
 
 asyncTest( 'require() doesn\'t execute', 1, function() {
 	var cancel = setTimeout(function() {


### PR DESCRIPTION
1. manage the case when localStorage could not be available on IOS private mode (which is the default). 
2. basket.ready(key) allow you to write a bunch of dependent files and get the promise asynchronously.
