### PR TITLE
trackFailures option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 bower_components
 _site
+.idea

--- a/_includes/api.md
+++ b/_includes/api.md
@@ -82,6 +82,20 @@ basket
 
 The second parameter to `then()` is a function that will be called if the promise is rejected. That is, if there was an error fetching the script. The only parameter to the error callback will be an Error object with details of the failure.
 
+**Error handling with trackFailures**
+
+```js
+basket
+	.require([{ url: 'missing.js' }], { trackFailures: true })
+	.then(function (responses) {
+		if ( responses[0].state === "rejected" ) {
+        	console.log(responses[0].reason.message); // Not Found
+        }
+	}, function(error) {
+		// This is not called
+	});
+```
+
 **Using an alias**
 
 ```js

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -45,6 +45,8 @@
 	};
 
 	var getUrl = function( url ) {
+		var timeout;
+
 		var promise = new RSVP.Promise( function( resolve, reject ){
 
 			var xhr = new XMLHttpRequest();
@@ -59,10 +61,10 @@
 							type: xhr.getResponseHeader('content-type')
 						} );
 					} else {
-						if ( xhr.status === 404 ) {
-							reject( new Error('Not Found') );
-						} else {
+						if ( timeout ) {
 							reject( new Error('Timeout') );
+						} else {
+							reject( new Error( xhr.statusText ) );
 						}
 					}
 				}
@@ -72,6 +74,7 @@
 			// spec for xhr.timeout. So we do it ourselves.
 			setTimeout( function () {
 				if( xhr.readyState < 4 ) {
+					timeout = true;
 					xhr.abort();
 				}
 			}, basket.timeout );

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -53,13 +53,17 @@
 			xhr.onreadystatechange = function() {
 				if ( xhr.readyState === 4 ) {
 					if ( ( xhr.status === 200 ) ||
-							( ( xhr.status === 0 ) && xhr.responseText ) ) {
+						( ( xhr.status === 0 ) && xhr.responseText ) ) {
 						resolve( {
 							content: xhr.responseText,
 							type: xhr.getResponseHeader('content-type')
 						} );
 					} else {
-						reject( new Error( xhr.statusText ) );
+						if ( xhr.status === 404 ) {
+							reject( new Error('Not Found') );
+						} else {
+							reject( new Error('Timeout') );
+						}
 					}
 				}
 			};
@@ -118,7 +122,7 @@
 
 		obj.key =  ( obj.key || obj.url );
 		source = basket.get( obj.key );
-                
+
 		obj.execute = obj.execute !== false;
 
 		shouldFetch = isCacheValid(source, obj);
@@ -189,6 +193,10 @@
 			promises.push( handleStackObject( arguments[ i ] ) );
 		}
 
+		if ( this !== null && this.trackFailures ) {
+			return RSVP.allSettled( promises );
+		}
+
 		return RSVP.all( promises );
 	};
 
@@ -203,17 +211,30 @@
 
 	window.basket = {
 		require: function() {
-			for ( var a = 0, l = arguments.length; a < l; a++ ) {
-				arguments[a].execute = arguments[a].execute !== false;
-				
-				if ( arguments[a].once && inBasket.indexOf(arguments[a].url) >= 0 ) {
-					arguments[a].execute = false;
-				} else if ( arguments[a].execute !== false && inBasket.indexOf(arguments[a].url) < 0 ) {  
-					inBasket.push(arguments[a].url);
+			var resources;
+			var options = null;
+
+			//  No change in current usage
+			if ( Array.isArray(arguments[0]) ) {
+				resources = arguments[0];
+				options = arguments[1] || null;
+			} else {
+				resources = arguments;
+			}
+
+			for ( var a = 0, l = resources.length; a < l; a++ ) {
+
+				// Set execute default to true
+				resources[a].execute = resources[a].execute !== false;
+
+				if ( resources[a].once && inBasket.indexOf(resources[a].url) >= 0 ) {
+					resources[a].execute = false;
+				} else if ( resources[a].execute !== false && inBasket.indexOf(resources[a].url) < 0 ) {
+					inBasket.push(resources[a].url);
 				}
 			}
-                        
-			var promise = fetch.apply( null, arguments ).then( performActions );
+
+			var promise = fetch.apply( options, resources ).then( performActions );
 
 			promise.thenRequire = thenRequire;
 			return promise;

--- a/test/tests.js
+++ b/test/tests.js
@@ -20,14 +20,14 @@ asyncTest( 'require() 1 script', 2, function() {
 	basket.require(
 		{url: 'fixtures/jquery.min.js'}
 	)
-	.then(function() {
-		clearTimeout( cancel );
+		.then(function() {
+			clearTimeout( cancel );
 
-		ok( true, 'Callback invoked' );
-		ok( basket.get('fixtures/jquery.min.js'), 'Data exists in localStorage' );
+			ok( true, 'Callback invoked' );
+			ok( basket.get('fixtures/jquery.min.js'), 'Data exists in localStorage' );
 
-		start();
-	});
+			start();
+		});
 });
 
 
@@ -38,9 +38,9 @@ asyncTest( 'require() 2 scripts with .then()', 3, function() {
 	}, 2500);
 
 	basket.require(
-			{ url: 'fixtures/jquery.min.js' },
-			{ url: 'fixtures/modernizr.min.js' }
-		)
+		{ url: 'fixtures/jquery.min.js' },
+		{ url: 'fixtures/modernizr.min.js' }
+	)
 		.then(function() {
 			clearTimeout( cancel );
 
@@ -60,9 +60,9 @@ asyncTest( 'require() 2 scripts (one non-executed) with .then()', 4, function() 
 	}, 2500);
 
 	basket.require(
-			{ url: 'fixtures/fail-script.js', execute: false },
-			{ url: 'fixtures/modernizr.min.js' }
-		)
+		{ url: 'fixtures/fail-script.js', execute: false },
+		{ url: 'fixtures/modernizr.min.js' }
+	)
 		.then(function() {
 			clearTimeout( cancel );
 
@@ -98,14 +98,14 @@ asyncTest( 'require() doesn\'t execute', 1, function() {
 	basket.require(
 		{ url: 'fixtures/executefalse.js', execute: false }
 	)
-	.then(function() {
+		.then(function() {
 
-		clearTimeout( cancel );
+			clearTimeout( cancel );
 
-		ok( typeof basket.executed === 'undefined', 'Scipt executed' );
+			ok( typeof basket.executed === 'undefined', 'Scipt executed' );
 
-		start();
-	});
+			start();
+		});
 });
 
 
@@ -118,21 +118,21 @@ asyncTest( 'require() twice doesn\'t execute on secound', 1, function() {
 	basket.require(
 		{ url: 'fixtures/executefalse2.js' }
 	)
-	.then(function() {
-		basket.executed2 = undefined;
-
-		basket.require(
-			{ url: 'fixtures/executefalse2.js', execute: false }
-		)
 		.then(function() {
+			basket.executed2 = undefined;
 
-			clearTimeout( cancel );
+			basket.require(
+				{ url: 'fixtures/executefalse2.js', execute: false }
+			)
+				.then(function() {
 
-			ok( typeof basket.executed2 === 'undefined', 'Scipt executed' );
+					clearTimeout( cancel );
 
-			start();
+					ok( typeof basket.executed2 === 'undefined', 'Scipt executed' );
+
+					start();
+				});
 		});
-	});
 });
 
 
@@ -145,18 +145,18 @@ asyncTest( 'require() once', 1, function() {
 	basket.require(
 		{ url: 'fixtures/once.js', once: true }
 	)
-	.then(function() {
-		basket.require(
-			{ url: 'fixtures/once.js', once: true }
-		)
 		.then(function() {
-			clearTimeout( cancel );
+			basket.require(
+				{ url: 'fixtures/once.js', once: true }
+			)
+				.then(function() {
+					clearTimeout( cancel );
 
-			ok( basket.once === 1, 'Script loaded twice' );
+					ok( basket.once === 1, 'Script loaded twice' );
 
-			start();
+					start();
+				});
 		});
-	});
 });
 
 
@@ -169,18 +169,18 @@ asyncTest( 'require() once (force reload)', 1, function() {
 	basket.require(
 		{ url: 'fixtures/once2.js', once: true }
 	)
-	.then(function() {
-		basket.require(
-			{ url: 'fixtures/once2.js' }
-		)
 		.then(function() {
-			clearTimeout( cancel );
+			basket.require(
+				{ url: 'fixtures/once2.js' }
+			)
+				.then(function() {
+					clearTimeout( cancel );
 
-			ok( basket.once2 === 2, 'Script loaded once' );
+					ok( basket.once2 === 2, 'Script loaded once' );
 
-			start();
+					start();
+				});
 		});
-	});
 });
 
 
@@ -199,9 +199,9 @@ asyncTest( 'clear()', 1, function() {
 asyncTest( 'clear( expired ) - remove only expired keys ', 2, function() {
 	basket
 		.require(
-			{ url: 'fixtures/largeScript.js', key: 'largeScript0', expire: -1 },
-			{ url: 'fixtures/largeScript.js', key: 'largeScript1' }
-		).then(function() {
+		{ url: 'fixtures/largeScript.js', key: 'largeScript0', expire: -1 },
+		{ url: 'fixtures/largeScript.js', key: 'largeScript1' }
+	).then(function() {
 			basket.clear( true );
 			// check if scripts added was removed from localStorage
 			ok( !basket.get( 'largeScript0' ) , 'Expired script removed' );
@@ -344,21 +344,21 @@ asyncTest( 'remove oldest script in localStorage when Quote Exceeded', 2, functi
 });
 
 /*
-asyncTest( 'file is larger than quota limit ', 2, function() {
-	basket
-		.require({ url: 'fixtures/largeScript.js', key: 'largeScript0' }, { url: 'fixtures/largeScript.js', key: 'largeScript1' })
-		.thenRequire({ url: 'fixtures/veryLargeScript.js', key: 'largeScript2' })
-		.then(function() {
-			// check if scripts added was removed from localStorage
-			ok( !basket.get( 'largeScript0' ) , 'First Script deleted' );
-			ok( !basket.get( 'largeScript1' ) , 'Second Script deleted' );
-			// check if the last script added still on localStorage
-			// TODO: Test is now failing in Chrome due to an anomoly,
-			// but passes in Safari. Investigate later.
-			// ok( !basket.get( 'largeScript2' ) , 'Last Script not added' );
-			start();
-		});
-});*/
+ asyncTest( 'file is larger than quota limit ', 2, function() {
+ basket
+ .require({ url: 'fixtures/largeScript.js', key: 'largeScript0' }, { url: 'fixtures/largeScript.js', key: 'largeScript1' })
+ .thenRequire({ url: 'fixtures/veryLargeScript.js', key: 'largeScript2' })
+ .then(function() {
+ // check if scripts added was removed from localStorage
+ ok( !basket.get( 'largeScript0' ) , 'First Script deleted' );
+ ok( !basket.get( 'largeScript1' ) , 'Second Script deleted' );
+ // check if the last script added still on localStorage
+ // TODO: Test is now failing in Chrome due to an anomoly,
+ // but passes in Safari. Investigate later.
+ // ok( !basket.get( 'largeScript2' ) , 'Last Script not added' );
+ start();
+ });
+ });*/
 
 asyncTest( 'non-existant file causes error handler to be called', 2, function() {
 	basket
@@ -429,14 +429,14 @@ asyncTest( 'when first file fails, second file is fetched but not executed', 3, 
 	basket.require({ url: '/first.js' })
 		.thenRequire({ url: '/second.js' })
 		.then( function() {},
-			function() {
-				ok( !basket.get( '/first.js' ), 'first script failed to load' );
-				ok( basket.get( '/second.js' ), 'second script was loaded and stored' );
-				ok( basket.second === 0, 'second script did not execute' );
+		function() {
+			ok( !basket.get( '/first.js' ), 'first script failed to load' );
+			ok( basket.get( '/second.js' ), 'second script was loaded and stored' );
+			ok( basket.second === 0, 'second script did not execute' );
 
-				start();
-				server.restore();
-			});
+			start();
+			server.restore();
+		});
 
 	server.respond();
 });
@@ -763,7 +763,7 @@ asyncTest( 'execute a cached script when execute: true', 2, function() {
 		basket.require(
 			{ url: 'fixtures/executefalse.js', execute: execute }
 		)
-		.then(cb);
+			.then(cb);
 	}
 
 	requireScript( false, function() {
@@ -777,4 +777,34 @@ asyncTest( 'execute a cached script when execute: true', 2, function() {
 			start();
 		});
 	});
+});
+
+asyncTest( 'with trackFailures: true and non-existant file, we call success handler', 1, function() {
+	basket
+		.require([{ url: 'non-existant.js'}], { trackFailures: true })
+		.then(function() {
+			ok( true, 'The success callback should be called' );
+			start();
+		});
+});
+
+asyncTest( 'without trackFailures: true and non-existant file, we call error handler', 1, function() {
+	basket
+		.require([{ url: 'non-existant.js'}])
+		.then(function() {
+			ok( false, 'The success callback should not be called' );
+			start();
+		}, function(error) {
+			ok( error, 'The error handler should be called' );
+			start();
+		});
+});
+
+asyncTest( 'with trackFailures: true and non-existant file, error message is Not Found', 1, function() {
+	basket
+		.require([{ url: 'non-existant.js'}], { trackFailures: true })
+		.then(function(responses) {
+			ok( responses[0].reason.message === 'Not Found', 'Reason message should be Not Found' );
+			start();
+		});
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -800,11 +800,11 @@ asyncTest( 'without trackFailures: true and non-existant file, we call error han
 		});
 });
 
-asyncTest( 'with trackFailures: true and non-existant file, error message is Not Found', 1, function() {
+asyncTest( 'with trackFailures: true and non-existant file, error message is available', 1, function() {
 	basket
 		.require([{ url: 'non-existant.js'}], { trackFailures: true })
 		.then(function(responses) {
-			ok( responses[0].reason.message === 'Not Found', 'Reason message should be Not Found' );
+			ok( typeof responses[0].reason.message !== 'undefined', 'Reason message should be defined' );
 			start();
 		});
 });


### PR DESCRIPTION
A basic option to track & inspect loading failures as described in https://github.com/addyosmani/basket.js/issues/152
- Added detection of timeout error.
- Added 3 tests.
- This will not work with thenRequire() chaining.

Usage:

``` js
basket
    .require([{ url: 'missing.js' }], { trackFailures: true })
    .then(function (responses) {
        if ( responses[0].state === "rejected" ) {
            console.log(responses[0].reason.message); // Not Found
        }
    }, function(error) {
        // This is not called
    });
```
