### PR TITLE
Allow promises to be based to basket.require

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -183,10 +183,11 @@
 	};
 
 	var fetch = function() {
-		var i, l, promises = [];
+		var i, l, current, promises = [];
 
 		for ( i = 0, l = arguments.length; i < l; i++ ) {
-			promises.push( handleStackObject( arguments[ i ] ) );
+			current = arguments[ i ];
+			promises.push( current.then ? current : handleStackObject( current ) );
 		}
 
 		return RSVP.all( promises );


### PR DESCRIPTION
This allows complex dependency chains to be encoded without sacraficing the upfront loading benefits from using .thenRequire.

This PR is the simplest way of achieving the desired effect, but it may make sense to refactor it so that `fetch` isn't responsible for this handling. Could also check if the passed object is a promise by checking `instanceof RSVP.Promise`.

If the maintainers are on board, I'll gladly add corresponding tests.

Example of the problem: 

``` js
// No dependencies
var a = basket.require(
  { url: 'a.js' }
);

// No dependencies
var b = basket.require(
  { url: 'b.js' }
);

// C depends on B
var c = b.thenRequire(
  { url: 'c.js' }
)

// D depends on A and C
// Can't currently encode this without sacraficing the benefit of thenRequire
var d = basket.require(a, c).thenRequire(
  { url: 'd.js' }
);
```

The naive solution:

``` js
// a,b, and c are all the same

// This promise doesn't have .thenRequire
var d = RSVP.all([a, c]).then(function() {
  // This won't start loading until a and b are done
  return basket.require(
    { url: 'd.js' }
  );
});
```
