### PR TITLE
add handler for css files

### DIFF
--- a/lib/basket.js
+++ b/lib/basket.js
@@ -151,19 +151,33 @@
 		return promise;
 	};
 
+	var absUrl = function( u ) {
+		if (!/^(\.|\w+:)/.test(u))
+			u = location.origin + location.pathname + u;
+		return u;
+	};
+
 	var injectScript = function( obj ) {
 		var script = document.createElement('script');
 		script.defer = true;
 		// Have to use .text, since we support IE8,
 		// which won't allow appending to a script
-		script.text = obj.data;
+		var content = obj.data;
+		if (!/\/\/[#@]\s+sourceURL=.*\s*$/.test(content)) {
+			content += '//# sourceURL=' + absUrl(obj.url);
+		}
+		script.text = content;
 		head.appendChild( script );
 	};
 
 	var injectStyle = function( obj ) {
 		var style = document.createElement('style');
 		style.type = 'text/css';
-		style.text = obj.data;
+		var content = obj.data;
+		if (!/\/\*#\s+sourceURL=.*\s+\*\/\s*$/.test(content)) {
+			content += '/*# sourceURL=' + absUrl(obj.url) + ' */';
+		}
+		style.textContent = content;
 		head.appendChild( style );
 	};
 

--- a/lib/basket.js
+++ b/lib/basket.js
@@ -160,8 +160,16 @@
 		head.appendChild( script );
 	};
 
+	var injectStyle = function( obj ) {
+		var style = document.createElement('style');
+		style.type = 'text/css';
+		style.text = obj.data;
+		head.appendChild( style );
+	};
+
 	var handlers = {
-		'default': injectScript
+		'default': injectScript,
+		'css': injectStyle
 	};
 
 	var execute = function( obj ) {


### PR DESCRIPTION
Add support to cache css files.
Note: all relative urls in the css files need to be relative to the displayed html file.
